### PR TITLE
enable ability to rename project. fix sorting of projects in chronological order of creation (oldest on the top)

### DIFF
--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -131,30 +131,52 @@ header {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 10px;
 }
 
 header .left {
     color: var(--primary-clr);
     display: flex;
     align-items: center;
-    gap: 20px;
+    gap: 5px;
+    margin-left: 6px;
+    flex: 1;
 }
 
-header .left figure {
+.page-icon {
     height: 35px;
+    display: block;
+}
+
+.page-icon.hidden {
+    display: none;
+}
+
+#page-title {
+    flex: 1;
+    color: var(--primary-clr);
+    font-size: 1.5rem;
+    font-weight: 500;
+    background-color: transparent;
+    border: none;
+    padding: 10px;
+    width: 100%;
+}
+
+#page-title:focus {
+    color: var(--black-clr);
+    border: 1px solid var(--dimmed);
 }
 
 .add-task {
+    display: flex;
+    justify-content: flex-end;
     color: var(--dimmed);
     transition: color .25s;
 }
 
 .add-task:hover {
     color: var(--primary-clr);
-}
-
-.add-task:active {
-    transform: scale(.97);
 }
 
 

--- a/src/controllers/App/createAppController.js
+++ b/src/controllers/App/createAppController.js
@@ -76,15 +76,19 @@ const createAppController = () => {
 
   const getProjects = (excludeInbox = true) => {
     const storedProjectsInJSONFormat = retrieveProjects();
-    let projects = storedProjectsInJSONFormat
-      .map((p) => recreateProjectFromJSON(p))
-      .sort((projectA, projectB) => projectA.getId() - projectB.getId());
+    let projects = storedProjectsInJSONFormat.map((p) =>
+      recreateProjectFromJSON(p)
+    );
 
     projects = excludeInbox
-      ? projects.filter((project) => project.getName() !== "Inbox")
+      ? projects
+          .filter((project) => project.getName() !== "Inbox")
+          .sort((projectA, projectB) => projectA.getId() - projectB.getId())
       : [
           ...projects.filter((p) => p.getId() === "inbox"),
-          ...projects.filter((p) => p.getId() !== "inbox"),
+          ...projects
+            .filter((p) => p.getId() !== "inbox")
+            .sort((projectA, projectB) => projectA.getId() - projectB.getId()),
         ];
 
     return projects;

--- a/src/controllers/App/createAppController.js
+++ b/src/controllers/App/createAppController.js
@@ -76,19 +76,15 @@ const createAppController = () => {
 
   const getProjects = (excludeInbox = true) => {
     const storedProjectsInJSONFormat = retrieveProjects();
-    let projects = storedProjectsInJSONFormat.map((p) =>
-      recreateProjectFromJSON(p)
-    );
+    let projects = storedProjectsInJSONFormat
+      .map((p) => recreateProjectFromJSON(p))
+      .sort((projectA, projectB) => projectB.getId() - projectA.getId());
 
     projects = excludeInbox
-      ? projects
-          .filter((project) => project.getName() !== "Inbox")
-          .sort((projectA, projectB) => projectA.getId() - projectB.getId())
+      ? projects.filter((project) => project.getName() !== "Inbox")
       : [
           ...projects.filter((p) => p.getId() === "inbox"),
-          ...projects
-            .filter((p) => p.getId() !== "inbox")
-            .sort((projectA, projectB) => projectA.getId() - projectB.getId()),
+          ...projects.filter((p) => p.getId() !== "inbox"),
         ];
 
     return projects;

--- a/src/controllers/App/createAppController.js
+++ b/src/controllers/App/createAppController.js
@@ -97,18 +97,28 @@ const createAppController = () => {
     newProject.store();
   };
 
+  const renameProject = (projectId, newProjectName) => {
+    const project = getProject(projectId);
+    project.setName(newProjectName);
+    project.store();
+
+    // if newProjectName is a duplicate, this should already be handled...
+    return;
+  };
+
   // run: this creates the inbox project
   if (localStorage.length === 0) createProject().store();
 
   return {
-    addTask,
     getTask,
+    addTask,
     updateTask,
-    deleteTask,
-    addProject,
-    getProjects,
-    getProject,
     updateTaskCompletion,
+    deleteTask,
+    getProject,
+    getProjects,
+    addProject,
+    renameProject,
   };
 };
 

--- a/src/controllers/App/createAppController.js
+++ b/src/controllers/App/createAppController.js
@@ -7,6 +7,9 @@ import {
 } from "../../helpers/localStorageHelpers";
 
 const createAppController = () => {
+  /* METHODS FOR TASKS */
+  const getTask = (taskId) => recreateTaskFromJSON(retrieveTaskById(taskId));
+
   const addTask = ({ name, description, dueDate, urgency, projectId }) => {
     if (!name) return;
     const newTask = createTask(name);
@@ -20,34 +23,6 @@ const createAppController = () => {
     project.addTask(newTask.getId());
     project.store();
   };
-
-  const addProject = (newProjectName) => {
-    if (!newProjectName) return;
-    const newProject = createProject();
-    newProject.setName(newProjectName);
-    newProject.store();
-  };
-
-  const getTask = (taskId) => recreateTaskFromJSON(retrieveTaskById(taskId));
-
-  const getProjects = (excludeInbox = true) => {
-    const storedProjectsInJSONFormat = retrieveProjects();
-    let projects = storedProjectsInJSONFormat
-      .map((p) => recreateProjectFromJSON(p))
-      .sort((projectA, projectB) => projectA.getId() - projectB.getId());
-
-    projects = excludeInbox
-      ? projects.filter((project) => project.getName() !== "Inbox")
-      : [
-          ...projects.filter((p) => p.getId() === "inbox"),
-          ...projects.filter((p) => p.getId() !== "inbox"),
-        ];
-
-    return projects;
-  };
-
-  const getProject = (projectId) =>
-    recreateProjectFromJSON(retrieveProjectById(projectId));
 
   const updateTask = ({
     id,
@@ -93,6 +68,33 @@ const createAppController = () => {
     project.removeTask(taskId);
     project.store();
     taskObject.remove();
+  };
+
+  /* METHODS FOR PROJECTS */
+  const getProject = (projectId) =>
+    recreateProjectFromJSON(retrieveProjectById(projectId));
+
+  const getProjects = (excludeInbox = true) => {
+    const storedProjectsInJSONFormat = retrieveProjects();
+    let projects = storedProjectsInJSONFormat
+      .map((p) => recreateProjectFromJSON(p))
+      .sort((projectA, projectB) => projectA.getId() - projectB.getId());
+
+    projects = excludeInbox
+      ? projects.filter((project) => project.getName() !== "Inbox")
+      : [
+          ...projects.filter((p) => p.getId() === "inbox"),
+          ...projects.filter((p) => p.getId() !== "inbox"),
+        ];
+
+    return projects;
+  };
+
+  const addProject = (newProjectName) => {
+    if (!newProjectName) return;
+    const newProject = createProject();
+    newProject.setName(newProjectName);
+    newProject.store();
   };
 
   // run: this creates the inbox project

--- a/src/controllers/App/createAppController.js
+++ b/src/controllers/App/createAppController.js
@@ -78,7 +78,10 @@ const createAppController = () => {
     const storedProjectsInJSONFormat = retrieveProjects();
     let projects = storedProjectsInJSONFormat
       .map((p) => recreateProjectFromJSON(p))
-      .sort((projectA, projectB) => projectB.getId() - projectA.getId());
+      .sort(
+        (a, b) =>
+          Number(a.getId().substring(1)) - Number(b.getId().substring(1))
+      );
 
     projects = excludeInbox
       ? projects.filter((project) => project.getName() !== "Inbox")

--- a/src/controllers/App/createAppController.js
+++ b/src/controllers/App/createAppController.js
@@ -97,13 +97,9 @@ const createAppController = () => {
     newProject.store();
   };
 
-  const renameProject = (projectId, newProjectName) => {
-    const project = getProject(projectId);
-    project.setName(newProjectName);
-    project.store();
-
-    // if newProjectName is a duplicate, this should already be handled...
-    return;
+  const renameProject = (projectObject, newProjectName) => {
+    projectObject.setName(newProjectName);
+    projectObject.store();
   };
 
   // run: this creates the inbox project

--- a/src/controllers/Screen/displayPage/handleProjectNameChange.js
+++ b/src/controllers/Screen/displayPage/handleProjectNameChange.js
@@ -1,0 +1,26 @@
+import addSuffixToDuplicateProjectName from "../../../helpers/addSuffixToDuplicateProjectNames";
+import { createAppController } from "../../App/createAppController";
+
+const app = createAppController();
+
+export default function handleProjectNameChange(e) {
+  const projectId = e.target.dataset.id;
+  const projectObject = app.getProject(projectId);
+  const oldName = projectObject.getName();
+
+  e.target.addEventListener(
+    "blur",
+    (evt) => {
+      let newName = evt.target.value;
+
+      if (oldName.trim() === newName.trim() || !newName.trim())
+        return (evt.target.value = oldName);
+
+      newName = addSuffixToDuplicateProjectName(newName);
+      evt.target.value = newName;
+
+      app.renameProject(projectObject, newName);
+    },
+    { once: true }
+  );
+}

--- a/src/controllers/Screen/displayPage/handleProjectNameChange.js
+++ b/src/controllers/Screen/displayPage/handleProjectNameChange.js
@@ -1,5 +1,6 @@
 import addSuffixToDuplicateProjectName from "../../../helpers/addSuffixToDuplicateProjectNames";
 import { createAppController } from "../../App/createAppController";
+import displayProjectsInNav from "../nav/displayProjectsInNav";
 
 const app = createAppController();
 
@@ -18,8 +19,8 @@ export default function handleProjectNameChange(e) {
 
       newName = addSuffixToDuplicateProjectName(newName);
       evt.target.value = newName;
-
       app.renameProject(projectObject, newName);
+      displayProjectsInNav();
     },
     { once: true }
   );

--- a/src/controllers/Screen/displayPage/updateHeader.js
+++ b/src/controllers/Screen/displayPage/updateHeader.js
@@ -1,6 +1,8 @@
-//todo: make svg imported - there is too much markup here...
-const SVGS = {
-  project: `<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none"
+import handleProjectNameChange from "./handleProjectNameChange";
+
+const updateHeader = (project) => {
+  const SVGS = {
+    project: `<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none"
                 stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
                 class="icon icon-tabler icons-tabler-outline icon-tabler-list">
                 <path stroke="none" d="M0 0h24v24H0z" fill="none" />
@@ -11,25 +13,24 @@ const SVGS = {
                 <path d="M5 12l0 .01" />
                 <path d="M5 18l0 .01" />
               </svg>`,
-  inbox: `<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none"
+    inbox: `<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none"
             stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
             class="icon icon-tabler icons-tabler-outline icon-tabler-inbox">
             <path stroke="none" d="M0 0h24v24H0z" fill="none" />
             <path d="M4 4m0 2a2 2 0 0 1 2 -2h12a2 2 0 0 1 2 2v12a2 2 0 0 1 -2 2h-12a2 2 0 0 1 -2 -2z" />
             <path d="M4 13h3l3 3h4l3 -3h3" />
           </svg>`,
-};
+  };
+  const pageIcon = document.querySelector(".page-icon");
+  const pageTitle = document.querySelector("#page-title");
 
-const updateHeader = (project) => {
-  const projectId = project.getId();
+  const currentProjectPageId = project.getId();
+  const isInboxPage = currentProjectPageId === "inbox";
 
-  const pageIcon = document.querySelector("header .left figure");
-  const pageTitle = document.querySelector(".page-title");
-  const navbarLink = document.querySelector(`[data-id="${projectId}"]`);
-
-  navbarLink.classList.add("selected");
-  pageTitle.textContent = project.getName();
-  pageIcon.innerHTML = projectId === "inbox" ? SVGS.inbox : SVGS.project;
+  pageTitle.value = project.getName();
+  pageTitle.setAttribute("data-id", currentProjectPageId);
+  pageTitle.disabled = isInboxPage;
+  pageIcon.innerHTML = isInboxPage ? SVGS.inbox : SVGS.project;
 };
 
 export default updateHeader;

--- a/src/controllers/Screen/index.js
+++ b/src/controllers/Screen/index.js
@@ -3,21 +3,24 @@ import addProjectUsingModal from "./modals/addProjectUsingModal";
 import displayProjectsInNav from "./nav/displayProjectsInNav";
 import displayPage from "./displayPage";
 import handleNavLinkClicks from "./nav/handleNavLinkClicks";
+import handleProjectNameChange from "./displayPage/handleProjectNameChange";
 
 const createScreenController = () => {
   const brandingInSidebar = document.querySelector(".branding");
   const inboxLinkInSidebar = document.querySelector("#inbox-link");
   const addProjectBtn = document.querySelector(".add-project");
   const addTaskBtn = document.querySelector(".add-task");
+  const pageTitle = document.querySelector("#page-title");
 
   displayProjectsInNav();
   displayPage("inbox");
 
   //event listeners
-  addTaskBtn.addEventListener("click", addTaskUsingModal);
-  addProjectBtn.addEventListener("click", addProjectUsingModal);
+  pageTitle.addEventListener("mousedown", handleProjectNameChange);
+  addTaskBtn.addEventListener("mousedown", addTaskUsingModal);
+  addProjectBtn.addEventListener("mousedown", addProjectUsingModal);
   [brandingInSidebar, inboxLinkInSidebar].forEach((elem) =>
-    elem.addEventListener("click", () => handleNavLinkClicks("inbox"))
+    elem.addEventListener("mousedown", () => handleNavLinkClicks("inbox"))
   );
 };
 

--- a/src/controllers/Screen/modals/addProjectUsingModal.js
+++ b/src/controllers/Screen/modals/addProjectUsingModal.js
@@ -3,9 +3,6 @@ import { closeModal } from "./taskModalsHandlers";
 import displayProjectsInNav from "../nav/displayProjectsInNav";
 
 const modal = document.querySelector(".new-project-modal");
-const inputAndErrorMessageElements = document.querySelector(
-  ".new-project-modal .top"
-).children;
 const form = document.querySelector(".new-project-modal form");
 const input = document.querySelector("#new-project-name");
 const cancelBtn = document.querySelector(".new-project-modal .cancel-btn");
@@ -26,16 +23,9 @@ function handleSubmit(e) {
 
   const app = createAppController();
 
-  // dealing with errors when project already exists
-  try {
-    app.addProject(input.value);
-    closeModal(modal);
-    displayProjectsInNav();
-  } catch {
-    [...inputAndErrorMessageElements].forEach((elem) =>
-      elem.classList.add("error")
-    );
-  }
+  app.addProject(input.value);
+  closeModal(modal);
+  displayProjectsInNav();
 }
 
 export default addProjectUsingModal;

--- a/src/controllers/Screen/nav/displayProjectsInNav.js
+++ b/src/controllers/Screen/nav/displayProjectsInNav.js
@@ -1,22 +1,23 @@
 import { createAppController } from "../../App/createAppController";
 import handleNavLinkClicks from "./handleNavLinkClicks";
 
+const app = createAppController();
+const navProjectsContainer = document.querySelector(
+  ".current-projects-container"
+);
+
 const displayProjectsInNav = () => {
-  const app = createAppController();
-  const navProjectsContainer = document.querySelector(
-    ".current-projects-container"
-  );
+  navProjectsContainer.replaceChildren();
 
-  const projectsArray = app
-    .getProjects()
-    .map((getProjectObject) => createProjectLinkInNav(getProjectObject));
-
-  navProjectsContainer.replaceChildren(...projectsArray);
+  const storedProjectObjects = app.getProjects();
+  storedProjectObjects.forEach((p) => createProjectLinkInNav(p));
 };
 
 const createProjectLinkInNav = (project) => {
   const projectName = project.getName();
   const projectId = project.getId();
+
+  console.log(projectId, projectName);
 
   const linkDiv = document.createElement("div");
   linkDiv.classList.add("link");
@@ -47,7 +48,7 @@ const createProjectLinkInNav = (project) => {
   linkAnchor.appendChild(projectNameText);
   linkDiv.appendChild(linkAnchor);
 
-  return linkDiv;
+  navProjectsContainer.appendChild(linkDiv);
 };
 
 export default displayProjectsInNav;

--- a/src/controllers/Screen/nav/handleNavLinkClicks.js
+++ b/src/controllers/Screen/nav/handleNavLinkClicks.js
@@ -1,12 +1,14 @@
 import displayPage from "../displayPage";
 
-function handleNavLinkClicks(projectName) {
+function handleNavLinkClicks(projectId) {
   const projectsIncludingInbox = document.querySelectorAll(
     "div[class=link], div.link.selected"
   );
-  // clear all previously selected pages (link has '.selected' attached)
+  const navbarLink = document.querySelector(`[data-id="${projectId}"]`);
+
   projectsIncludingInbox.forEach((div) => div.classList.remove("selected"));
-  displayPage(projectName);
+  navbarLink.classList.add("selected");
+  displayPage(projectId);
 }
 
 export default handleNavLinkClicks;

--- a/src/helpers/addSuffixToDuplicateProjectNames.js
+++ b/src/helpers/addSuffixToDuplicateProjectNames.js
@@ -5,7 +5,6 @@ import {
 
 export default function addSuffixToDuplicateProjectName(projectName) {
   const projectNamesInStorage = retrieveProjectNames();
-  console.log("project names in storage", projectNamesInStorage);
   const cleanedProjectNamesInStorage = getCleanedProjectNames();
   const regexToMatchParenthesesWithNumbersInside = /\(\s*\d+\s*\)$/g;
   const cleanedProjectName = projectName

--- a/src/helpers/addSuffixToDuplicateProjectNames.js
+++ b/src/helpers/addSuffixToDuplicateProjectNames.js
@@ -1,0 +1,30 @@
+import {
+  getCleanedProjectNames,
+  retrieveProjectNames,
+} from "../helpers/localStorageHelpers";
+
+export default function addSuffixToDuplicateProjectName(projectName) {
+  const projectNamesInStorage = retrieveProjectNames();
+  console.log("project names in storage", projectNamesInStorage);
+  const cleanedProjectNamesInStorage = getCleanedProjectNames();
+  const regexToMatchParenthesesWithNumbersInside = /\(\s*\d+\s*\)$/g;
+  const cleanedProjectName = projectName
+    .replace(regexToMatchParenthesesWithNumbersInside, "")
+    .trim();
+  const projectNameExistsInStorage = projectNamesInStorage.some(
+    (name) => name === projectName
+  );
+
+  const duplicateCount = cleanedProjectNamesInStorage.filter(
+    (cleanedName) => cleanedName === cleanedProjectName
+  ).length;
+
+  if (!projectNameExistsInStorage) return projectName;
+  if (!projectNamesInStorage.includes(cleanedProjectName))
+    return cleanedProjectName;
+
+  for (let suffixInt = 1; suffixInt <= duplicateCount; suffixInt++) {
+    const suffixedName = `${cleanedProjectName} (${suffixInt})`;
+    if (!projectNamesInStorage.includes(suffixedName)) return suffixedName;
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -55,16 +55,8 @@
 
     <header>
       <div class="left">
-        <figure>
-          <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none"
-            stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-            class="icon icon-tabler icons-tabler-outline icon-tabler-inbox">
-            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-            <path d="M4 4m0 2a2 2 0 0 1 2 -2h12a2 2 0 0 1 2 2v12a2 2 0 0 1 -2 2h-12a2 2 0 0 1 -2 -2z" />
-            <path d="M4 13h3l3 3h4l3 -3h3" />
-          </svg>
-        </figure>
-        <h1 class="page-title">Inbox</h1>
+        <figure class="page-icon"></figure>
+        <input type="text" id="page-title" class="page-title" onclick="this.select()"></input>
       </div>
       <div class="links-container add-task">
         <a href="#">

--- a/src/models/Project.js
+++ b/src/models/Project.js
@@ -1,6 +1,5 @@
+import addSuffixToDuplicateProjectName from "../helpers/addSuffixToDuplicateProjectNames";
 import {
-  getCleanedProjectNames,
-  retrieveProjectNames,
   retrieveProjects,
   retrieveTaskById,
 } from "../helpers/localStorageHelpers";
@@ -22,23 +21,9 @@ const createProject = (recreatingFromJSON = false) => {
 
   // SETTERS
   const setName = (retrievedOrNewName) => {
-    const projectNamesInStorage = retrieveProjectNames();
-    const cleanedProjectNamesInStorage = getCleanedProjectNames();
-    const projectNameExists =
-      projectNamesInStorage.includes(retrievedOrNewName);
-
-    if (!projectNameExists || recreatingFromJSON)
-      return (name = retrievedOrNewName);
-
-    const duplicateCount = cleanedProjectNamesInStorage.filter(
-      (n) => n === retrievedOrNewName
-    ).length;
-
-    for (let suffixInt = 1; suffixInt <= duplicateCount; suffixInt++) {
-      const projectNameWithSuffix = `${retrievedOrNewName} (${suffixInt})`;
-      if (!projectNamesInStorage.includes(projectNameWithSuffix))
-        return (name = projectNameWithSuffix);
-    }
+    if (recreatingFromJSON) return (name = retrievedOrNewName);
+    name = addSuffixToDuplicateProjectName(retrievedOrNewName);
+    console.log(name);
   };
 
   const setId = (retrievedId) => {

--- a/src/models/Project.js
+++ b/src/models/Project.js
@@ -23,7 +23,6 @@ const createProject = (recreatingFromJSON = false) => {
   const setName = (retrievedOrNewName) => {
     if (recreatingFromJSON) return (name = retrievedOrNewName);
     name = addSuffixToDuplicateProjectName(retrievedOrNewName);
-    console.log(name);
   };
 
   const setId = (retrievedId) => {


### PR DESCRIPTION
fixes #29
fixes #30 
fixes #34 (by moving the event listener higher up to the screenController level (rather than more deeply nested in the `displayPage / updateHeader.js` for example, which kept repeatedly calling the eventhandler for some odd reason i couldnt understand)
begins to address #35, but the bug there is quite hard to detect and can be deprioritised until future releases