### PR TITLE
sort tasks by completion status, due date, then creation date

### DIFF
--- a/src/controllers/Screen/displayPage/displayTasks.js
+++ b/src/controllers/Screen/displayPage/displayTasks.js
@@ -3,6 +3,7 @@ import displayTaskDetailsInModal from "../modals/displayTaskDetailsInModal";
 import { createAppController } from "../../App/createAppController";
 import displayPage from ".";
 import confirmTaskDeletion from "../modals/deletion/confirmTaskDeletion";
+import sortTasks from "./sortTasks";
 
 const SVGS = {
   dueDate: `<svg xmlns="http://www.w3.org/2000/svg" width="17" height="17" viewBox="0 0 24 24" fill="none"
@@ -25,6 +26,8 @@ const tasksContainer = document.querySelector("main .container");
 const displayTasks = (project) => {
   const taskObjects = project.getTasksAsObjects();
   if (!taskObjects) return;
+
+  console.log(sortTasks(taskObjects));
 
   tasksContainer.replaceChildren();
 

--- a/src/controllers/Screen/displayPage/displayTasks.js
+++ b/src/controllers/Screen/displayPage/displayTasks.js
@@ -27,11 +27,10 @@ const displayTasks = (project) => {
   const taskObjects = project.getTasksAsObjects();
   if (!taskObjects) return;
 
-  console.log(sortTasks(taskObjects));
-
   tasksContainer.replaceChildren();
 
-  taskObjects.forEach((taskObject) => {
+  const sortedTasks = sortTasks(taskObjects);
+  sortedTasks.forEach((taskObject) => {
     const taskArticleElement = generateTaskDiv(taskObject);
     tasksContainer.appendChild(taskArticleElement);
   });

--- a/src/controllers/Screen/displayPage/sortTasks.js
+++ b/src/controllers/Screen/displayPage/sortTasks.js
@@ -16,5 +16,4 @@ export default function sortTasks(taskObjectsArray) {
   );
 
   return [...tasksWithDueDates, ...tasksWithoutDueDates];
-  //  ! ensure sorting is done after every modification of every task detail too
 }

--- a/src/controllers/Screen/displayPage/sortTasks.js
+++ b/src/controllers/Screen/displayPage/sortTasks.js
@@ -1,4 +1,20 @@
 export default function sortTasks(taskObjectsArray) {
-  alert("sorting");
+  if (taskObjectsArray.length === 0) return taskObjectsArray;
+
+  // isolate the tasks that do have a due date
+  const tasksWithDueDates = taskObjectsArray.filter((t) => t.getDueDate());
+  console.log(tasksWithDueDates);
+
+  // then, for tasks that don't have a due date, we sort by creation date (proxied by their ids)
+
+  // use spread operator to combine them
+
+  //   const sortedArray = taskObjectsArray.sort((a, b) => {
+  //     console.log(new Date(a.getDueDate()), new Date(b.getDueDate()));
+  //     return a - b;
+  //   });
+
+  //  ! ensure sorting is done after every modification of every task detail too
+
   return taskObjectsArray; // but sorted
 }

--- a/src/controllers/Screen/displayPage/sortTasks.js
+++ b/src/controllers/Screen/displayPage/sortTasks.js
@@ -3,10 +3,14 @@ export default function sortTasks(taskObjectsArray) {
 
   // isolate the tasks that do have a due date
   const tasksWithDueDates = taskObjectsArray.filter((t) => t.getDueDate());
+  tasksWithDueDates.sort(
+    (taskA, taskB) =>
+      new Date(taskA.getDueDate()) - new Date(taskB.getDueDate())
+  );
+  //   tasksWithDueDates.forEach((t) => console.log(t.viewDetails()));
 
   // then, for tasks that don't have a due date, we sort by creation date (proxied by their ids)
   const tasksNoDueDates = taskObjectsArray.filter((t) => t.getDueDate() === "");
-  console.log(tasksNoDueDates);
 
   // use spread operator to combine them
 
@@ -17,5 +21,5 @@ export default function sortTasks(taskObjectsArray) {
 
   //  ! ensure sorting is done after every modification of every task detail too
 
-  return taskObjectsArray; // but sorted
+  return tasksWithDueDates; // but sorted
 }

--- a/src/controllers/Screen/displayPage/sortTasks.js
+++ b/src/controllers/Screen/displayPage/sortTasks.js
@@ -1,0 +1,4 @@
+export default function sortTasks(taskObjectsArray) {
+  alert("sorting");
+  return taskObjectsArray; // but sorted
+}

--- a/src/controllers/Screen/displayPage/sortTasks.js
+++ b/src/controllers/Screen/displayPage/sortTasks.js
@@ -10,7 +10,15 @@ export default function sortTasks(taskObjectsArray) {
   //   tasksWithDueDates.forEach((t) => console.log(t.viewDetails()));
 
   // then, for tasks that don't have a due date, we sort by creation date (proxied by their ids)
-  const tasksNoDueDates = taskObjectsArray.filter((t) => t.getDueDate() === "");
+  const tasksWithoutDueDates = taskObjectsArray.filter(
+    (t) => t.getDueDate() === ""
+  );
+  tasksWithoutDueDates.sort(
+    (taskA, taskB) =>
+      Number(taskA.getId().substring(1)) - Number(taskB.getId().substring(1))
+  );
+
+  console.log(tasksWithoutDueDates[0].viewDetails());
 
   // use spread operator to combine them
 
@@ -21,5 +29,5 @@ export default function sortTasks(taskObjectsArray) {
 
   //  ! ensure sorting is done after every modification of every task detail too
 
-  return tasksWithDueDates; // but sorted
+  return tasksWithoutDueDates; // but sorted
 }

--- a/src/controllers/Screen/displayPage/sortTasks.js
+++ b/src/controllers/Screen/displayPage/sortTasks.js
@@ -1,6 +1,9 @@
 export default function sortTasks(taskObjectsArray) {
   if (taskObjectsArray.length === 0) return taskObjectsArray;
 
+  const completedTasks = taskObjectsArray.filter((t) => t.getCompleted());
+  //   return completedTasks;
+
   const tasksWithDueDates = taskObjectsArray.filter((t) => t.getDueDate());
   tasksWithDueDates.sort(
     (taskA, taskB) =>
@@ -17,3 +20,9 @@ export default function sortTasks(taskObjectsArray) {
 
   return [...tasksWithDueDates, ...tasksWithoutDueDates];
 }
+
+const earlierDueDateComesFirst = (taskA, taskB) =>
+  new Date(taskA.getDueDate()) - new Date(taskB.getDueDate());
+
+const earlierCreationDateComesFirst = (taskA, taskB) =>
+  Number(taskA.getId().substring(1)) - Number(taskB.getId().substring(1));

--- a/src/controllers/Screen/displayPage/sortTasks.js
+++ b/src/controllers/Screen/displayPage/sortTasks.js
@@ -3,9 +3,10 @@ export default function sortTasks(taskObjectsArray) {
 
   // isolate the tasks that do have a due date
   const tasksWithDueDates = taskObjectsArray.filter((t) => t.getDueDate());
-  console.log(tasksWithDueDates);
 
   // then, for tasks that don't have a due date, we sort by creation date (proxied by their ids)
+  const tasksNoDueDates = taskObjectsArray.filter((t) => t.getDueDate() === "");
+  console.log(tasksNoDueDates);
 
   // use spread operator to combine them
 

--- a/src/controllers/Screen/displayPage/sortTasks.js
+++ b/src/controllers/Screen/displayPage/sortTasks.js
@@ -2,24 +2,31 @@ export default function sortTasks(taskObjectsArray) {
   if (taskObjectsArray.length === 0) return taskObjectsArray;
 
   const completedTasks = taskObjectsArray.filter((t) => t.getCompleted());
+  const completedTasksWithDueDates = completedTasks.filter((t) =>
+    t.getDueDate()
+  );
+  const completedTasksWithoutDueDates = completedTasks.filter(
+    (t) => !t.getDueDate()
+  );
+  const completedTasksSorted = [
+    ...completedTasksWithDueDates.sort(earlierDueDateComesFirst),
+    ...completedTasksWithoutDueDates.sort(earlierCreationDateComesFirst),
+  ];
+
   const incompleteTasks = taskObjectsArray.filter((t) => !t.getCompleted());
-  //   return incompleteTasks;
-
-  const tasksWithDueDates = taskObjectsArray.filter((t) => t.getDueDate());
-  tasksWithDueDates.sort(
-    (taskA, taskB) =>
-      new Date(taskA.getDueDate()) - new Date(taskB.getDueDate())
+  const incompleteTasksWithDueDates = incompleteTasks.filter((t) =>
+    t.getDueDate()
+  );
+  const incompleteTasksWithoutDueDates = incompleteTasks.filter(
+    (t) => !t.getDueDate()
   );
 
-  const tasksWithoutDueDates = taskObjectsArray.filter(
-    (t) => t.getDueDate() === ""
-  );
-  tasksWithoutDueDates.sort(
-    (taskA, taskB) =>
-      Number(taskA.getId().substring(1)) - Number(taskB.getId().substring(1))
-  );
+  const incompleteTasksSorted = [
+    ...incompleteTasksWithDueDates.sort(earlierDueDateComesFirst),
+    ...incompleteTasksWithoutDueDates.sort(earlierCreationDateComesFirst),
+  ];
 
-  return [...tasksWithDueDates, ...tasksWithoutDueDates];
+  return [...incompleteTasksSorted, ...completedTasksSorted];
 }
 
 const earlierDueDateComesFirst = (taskA, taskB) =>

--- a/src/controllers/Screen/displayPage/sortTasks.js
+++ b/src/controllers/Screen/displayPage/sortTasks.js
@@ -2,7 +2,8 @@ export default function sortTasks(taskObjectsArray) {
   if (taskObjectsArray.length === 0) return taskObjectsArray;
 
   const completedTasks = taskObjectsArray.filter((t) => t.getCompleted());
-  //   return completedTasks;
+  const incompleteTasks = taskObjectsArray.filter((t) => !t.getCompleted());
+  //   return incompleteTasks;
 
   const tasksWithDueDates = taskObjectsArray.filter((t) => t.getDueDate());
   tasksWithDueDates.sort(

--- a/src/controllers/Screen/displayPage/sortTasks.js
+++ b/src/controllers/Screen/displayPage/sortTasks.js
@@ -1,15 +1,12 @@
 export default function sortTasks(taskObjectsArray) {
   if (taskObjectsArray.length === 0) return taskObjectsArray;
 
-  // isolate the tasks that do have a due date
   const tasksWithDueDates = taskObjectsArray.filter((t) => t.getDueDate());
   tasksWithDueDates.sort(
     (taskA, taskB) =>
       new Date(taskA.getDueDate()) - new Date(taskB.getDueDate())
   );
-  //   tasksWithDueDates.forEach((t) => console.log(t.viewDetails()));
 
-  // then, for tasks that don't have a due date, we sort by creation date (proxied by their ids)
   const tasksWithoutDueDates = taskObjectsArray.filter(
     (t) => t.getDueDate() === ""
   );
@@ -18,16 +15,6 @@ export default function sortTasks(taskObjectsArray) {
       Number(taskA.getId().substring(1)) - Number(taskB.getId().substring(1))
   );
 
-  console.log(tasksWithoutDueDates[0].viewDetails());
-
-  // use spread operator to combine them
-
-  //   const sortedArray = taskObjectsArray.sort((a, b) => {
-  //     console.log(new Date(a.getDueDate()), new Date(b.getDueDate()));
-  //     return a - b;
-  //   });
-
+  return [...tasksWithDueDates, ...tasksWithoutDueDates];
   //  ! ensure sorting is done after every modification of every task detail too
-
-  return tasksWithoutDueDates; // but sorted
 }


### PR DESCRIPTION
fixes #27 (though expanded its scope)

1. incomplete tasks with due dates earlier are higher
2. incomplete tasks without due dates, but created earlier (proxied by its `id` property) are higher
3. complete tasks with due dates earlier are higher
4. complete tasks without due dates, but created earlier (proxied by its `id` property) are higher